### PR TITLE
Added hot module replacement for webpack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "jest",
     "start": "nodemon ./server/index.js",
-    "build": "webpack -w"
+    "build": "webpack -w",
+    "serve": "npx webpack-dev-server --config webpack.config.js"
   },
   "repository": {
     "type": "git",
@@ -27,14 +28,14 @@
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
     "axios": "^0.24.0",
-    "bourbon": "^7.0.0",
     "css-loader": "^6.5.0",
     "express": "^4.17.1",
     "jquery": "^3.6.0",
     "postcss-loader": "^6.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "style-loader": "^3.3.1"
+    "style-loader": "^3.3.1",
+    "webpack-dev-server": "^4.4.0"
   },
   "devDependencies": {
     "@testing-library/react": "^12.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,11 +5,18 @@ const SRC_DIR = path.resolve(__dirname, 'client', 'src');
 const SRC_FILE = path.resolve(SRC_DIR, 'index.jsx');
 
 module.exports = {
-  devtool: 'source-map',
   entry: ['babel-polyfill', SRC_FILE],
   output: {
     filename: 'bundle.js',
     path: DIST_DIR,
+  },
+  devServer: {
+    static: {
+      directory: DIST_DIR
+    },
+    compress: true,
+    port: 9000,
+    hot: true
   },
   mode: 'development',
   module: {


### PR DESCRIPTION
`npm install` for new webpack-dev-server package

and then

`npm start` to run Express serve
* ALSO *
`npm run serve` to run webpack server.

The page will serve static files at port 9000 and refresh if you save the page. Very useful for CSS !